### PR TITLE
Mapper processor improvements: Update dependencies, add option to inc…

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -133,10 +133,11 @@ compose.desktop {
 }
 
 ksp {
-    arg("render.mapper.engine", "true")
-    arg("module.prefix", "Home")
-    arg("di.plugin", "koin")
-    arg("include.default.serializer", "true")
+    arg("DP_RENDER_MAPPER_ENGINE", "true")
+    arg("DP_MODULE_PREFIX", "Home")
+    arg("DP_DI_PLUGIN", "koin")
+    arg("DP_INCLUDE_DEFAULT_SERIALIZER", "true")
+    arg("DP_INCLUDE_KOIN_MODULE", "true")
 
     arg("KOIN_CONFIG_CHECK","false")
     arg("KOIN_USE_COMPOSE_VIEWMODEL","true")

--- a/composeApp/src/commonMain/kotlin/com/nucu/dynamicpages/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/nucu/dynamicpages/App.kt
@@ -15,12 +15,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import com.nucu.dynamicpages.data.mappers.HomeContactResponseMapper
+import com.nucu.dynamicpages.data.mappers.HomeTestResponseMapper
 import com.nucu.dynamicpages.di.HomeDynamicPagesModule
-import com.nucu.dynamicpages.test.model.ContactResponse
-import com.nucu.dynamicpages.test.model.PhoneResponse
+import com.nucu.dynamicpages.test.model.TestResponse
 import com.nucu.dynamicpages.test.rule.MainModule
-import com.nucu.dynamicpages.test.rule.NameRule
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.KoinApplication
 import org.koin.compose.koinInject
@@ -45,8 +43,7 @@ fun App() {
 
 @Composable
 fun AppContent(modifier: Modifier = Modifier) {
-    val rule = koinInject<NameRule>()
-    val mapper = koinInject<HomeContactResponseMapper>()
+    val mapper2 = koinInject<HomeTestResponseMapper>()
 
     var showContent by remember { mutableStateOf(false) }
     Column(modifier, horizontalAlignment = Alignment.CenterHorizontally) {
@@ -56,12 +53,9 @@ fun AppContent(modifier: Modifier = Modifier) {
         AnimatedVisibility(showContent) {
             val greeting = remember { mutableStateOf("Loading...") }
             LaunchedEffect(Unit) {
-                greeting.value = mapper.mapToPhoneUi(
-                    contactResponse = ContactResponse(
-                        name = "Francisco",
-                        phone = PhoneResponse(
-                            country = "Mexico"
-                        )
+                greeting.value = mapper2.mapToTestUi(
+                    testResponse = TestResponse(
+                        name = "Javi"
                     )
                 ).toString()
             }

--- a/dynamic-pages-mapper-processor/src/jvmMain/kotlin/com/nucu/dynamicpages/render/processor/processors/MapperProcessor.kt
+++ b/dynamic-pages-mapper-processor/src/jvmMain/kotlin/com/nucu/dynamicpages/render/processor/processors/MapperProcessor.kt
@@ -7,7 +7,9 @@ import com.google.devtools.ksp.symbol.KSAnnotated
 import com.nucu.dynamicpages.render.processor.creators.mapper.KoinModuleCreator
 import com.nucu.dynamicpages.render.processor.creators.mapper.MapperCreator
 import com.nucu.dynamicpages.render.processor.creators.mapper.RenderMapperCreator
+import com.nucu.ksp.common.definitions.DefinitionNames.ENGINE_KEY
 import com.nucu.ksp.common.extensions.getDependencyInjectionPlugin
+import com.nucu.ksp.common.extensions.includeKoinModule
 import com.nucu.ksp.common.extensions.logEndProcessor
 import com.nucu.ksp.common.extensions.logStartProcessor
 import com.nucu.ksp.common.model.DependencyInjectionPlugin
@@ -17,11 +19,6 @@ import kotlin.time.measureTime
 import kotlin.time.toJavaDuration
 
 private const val PROCESSOR_NAME = "Mapper Processor"
-
-/**
- * This key allows to create render mapper class.
- */
-private const val ENGINE_KEY = "render.mapper.engine"
 
 internal class MapperProcessor(
     private val logger: KSPLogger,
@@ -55,7 +52,7 @@ internal class MapperProcessor(
             async { renderMapperCreator.start(resolver) }.await()
         } else emptyList()
 
-        if (options.getDependencyInjectionPlugin() == DependencyInjectionPlugin.KOIN) {
+        if (options.getDependencyInjectionPlugin() == DependencyInjectionPlugin.KOIN && options.includeKoinModule()) {
             koinModuleCreator.start(resolver)
         }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-dynamicPages = "1.0.4"
+dynamicPages = "1.0.5"
 agp = "8.8.0"
 android-compileSdk = "35"
 android-minSdk = "24"
@@ -13,8 +13,8 @@ ksp = "2.1.0-1.0.29"
 kotlinSerialization = "1.8.0"
 kotlinReflect = "2.1.0"
 kotlinPoet = "2.0.0"
-koin = "4.0.1"
-koin-annotations = "2.0.0-Beta2"
+koin = "4.0.2"
+koin-annotations = "2.0.0-RC1"
 vanniktech = "0.29.0"
 
 [libraries]

--- a/ksp-common/src/jvmMain/kotlin/com/nucu/ksp/common/definitions/DefinitionNames.kt
+++ b/ksp-common/src/jvmMain/kotlin/com/nucu/ksp/common/definitions/DefinitionNames.kt
@@ -52,9 +52,18 @@ object DefinitionNames {
     /**
      * Should be used to name any class to distinct it from other classes.
      */
-    const val MODULE_PREFIX = "module.prefix"
+    const val MODULE_PREFIX = "DP_MODULE_PREFIX"
 
-    const val DI_PLUGIN = "di.plugin"
+    /**
+     * This key allows to create render mapper class.
+     */
+    const val ENGINE_KEY = "DP_RENDER_MAPPER_ENGINE"
+
+    const val KEY_DEFAULT_SERIALIZER = "DP_INCLUDE_DEFAULT_SERIALIZER"
+
+    const val KEY_INCLUDE_KOIN_MODULE = "DP_INCLUDE_KOIN_MODULE"
+
+    const val DI_PLUGIN = "DP_DI_PLUGIN"
 
     const val PACKAGE_JAVAX_INJECT = "javax.inject.Inject"
 

--- a/ksp-common/src/jvmMain/kotlin/com/nucu/ksp/common/extensions/Extensions.kt
+++ b/ksp-common/src/jvmMain/kotlin/com/nucu/ksp/common/extensions/Extensions.kt
@@ -1,14 +1,16 @@
+@file:Suppress("TooManyFunctions")
 package com.nucu.ksp.common.extensions
 
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSDeclaration
-import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSValueArgument
 import com.google.devtools.ksp.validate
 import com.nucu.ksp.common.definitions.DefinitionNames
+import com.nucu.ksp.common.definitions.DefinitionNames.KEY_DEFAULT_SERIALIZER
+import com.nucu.ksp.common.definitions.DefinitionNames.KEY_INCLUDE_KOIN_MODULE
 import com.nucu.ksp.common.model.DependencyInjectionPlugin
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
@@ -119,20 +121,6 @@ fun Sequence<KSAnnotation>.filterByAnnotation(annotationName: String): Sequence<
 }
 
 /**
- * Find property by name.
- */
-fun Sequence<KSPropertyDeclaration>.findProperty(name: String): KSPropertyDeclaration? {
-    return this.firstOrNull { it.simpleName.getShortName() == name }
-}
-
-/**
- * Check if type is a collection or single.
- */
-fun KSDeclaration.isListType(): Boolean {
-    return qualifiedName?.getShortName() == "List"
-}
-
-/**
  * Return value of module prefix name parameter.
  */
 fun Map<String, String>.getModulePrefixName(): String {
@@ -149,5 +137,9 @@ fun Map<String, String>.getDependencyInjectionPlugin(): DependencyInjectionPlugi
 }
 
 fun Map<String, String>.includeDefaultSerializer(): Boolean {
-    return getOrDefault("include.default.serializer", "true").toBoolean()
+    return getOrDefault(KEY_DEFAULT_SERIALIZER, "true").toBoolean()
+}
+
+fun Map<String, String>.includeKoinModule(): Boolean {
+    return getOrDefault(KEY_INCLUDE_KOIN_MODULE, "true").toBoolean()
 }


### PR DESCRIPTION
…lude koin module, improve class name definition, and use ksp arguments

- Updates the `dynamicPages` and `koin` dependencies to `1.0.5` and `4.0.2` respectively.
- Adds a new option `DP_INCLUDE_KOIN_MODULE` to control whether to include the Koin module during processing.
- Introduces `DefinitionNames` for constants related to ksp arguments.
- Renames the prefix for modules to `DP_MODULE_PREFIX`.
- Adds `DP_RENDER_MAPPER_ENGINE` key to enable render mapper.
- Adds `DP_INCLUDE_DEFAULT_SERIALIZER` to enable default serializer.
- Adds koin module to render mapper if `DP_INCLUDE_KOIN_MODULE` is true.
- Use ksp arguments to define params.
- Add `HomeTestResponseMapper` and call it from `AppContent` to render.