### PR TITLE
feat: Update Dynamic Pages library version

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nucu/dynamicpages/test/RenderType.kt
+++ b/composeApp/src/commonMain/kotlin/com/nucu/dynamicpages/test/RenderType.kt
@@ -2,4 +2,5 @@ package com.nucu.dynamicpages.test
 
 object RenderType {
     const val TEXT = "text"
+    const val TABS = "tabs"
 }

--- a/composeApp/src/commonMain/kotlin/com/nucu/dynamicpages/test/model/response/TabsResponse.kt
+++ b/composeApp/src/commonMain/kotlin/com/nucu/dynamicpages/test/model/response/TabsResponse.kt
@@ -1,0 +1,16 @@
+package com.nucu.dynamicpages.test.model.response
+
+import com.nucu.dynamicpages.processor.annotations.render.RenderModel
+import com.nucu.dynamicpages.test.RenderType
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@RenderModel(
+    matchWith = [
+        RenderType.TABS
+    ]
+)
+@Serializable
+data class TabsResponse(
+    @SerialName("text") val text: String? = null
+)

--- a/composeApp/src/commonMain/kotlin/com/nucu/dynamicpages/test/model/ui/TabsUi.kt
+++ b/composeApp/src/commonMain/kotlin/com/nucu/dynamicpages/test/model/ui/TabsUi.kt
@@ -1,0 +1,15 @@
+package com.nucu.dynamicpages.test.model.ui
+
+import com.nucu.dynamicpages.processor.annotations.mapper.Mapper
+import com.nucu.dynamicpages.test.RenderType
+import com.nucu.dynamicpages.test.model.response.TabsResponse
+
+@Mapper(
+    matchWith = [
+        RenderType.TABS
+    ],
+    parent = TabsResponse::class
+)
+data class TabsUi(
+    val text: String
+)

--- a/dynamic-pages-mapper-processor/src/jvmMain/kotlin/com/nucu/dynamicpages/render/processor/creators/mapper/MapperCreator.kt
+++ b/dynamic-pages-mapper-processor/src/jvmMain/kotlin/com/nucu/dynamicpages/render/processor/creators/mapper/MapperCreator.kt
@@ -304,7 +304,9 @@ class MapperCreator(
 
             // Add necessary imports.
             addImport("", names = rules.map { it.toString() })
-            addImport("", names = listOf(responseModel.toString()))
+            if (responseModel != null) {
+                addImport("", names = listOf(responseModel.toString()))
+            }
 
             val returnPropList = properties.map { model ->
                 val newDeepNode = model.fromDeepNode ?: deepNode.orEmpty()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-dynamicPages = "1.2.0"
+dynamicPages = "1.2.1"
 agp = "8.10.1"
 android-compileSdk = "35"
 android-minSdk = "24"


### PR DESCRIPTION
- Updated Dynamic Pages version from 1.2.0 to 1.2.1 in `gradle/libs.versions.toml`.
- Modified `MapperCreator.kt` to conditionally import `responseModel` only if it's not null.